### PR TITLE
Handle different keyboard open functions

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -16,7 +16,13 @@ function enable() {
     gesture.connect('activated', Lang.bind(this, function() {
             Main.keyboard._keyboardRequested = true;
             Main.keyboard._keyboardVisible = false;
-            Main.keyboard.Show(global.get_current_time());
+            if(typeof Main.keyboard.Show === 'function') {
+                Main.keyboard.Show(global.get_current_time()); // up to 3.28
+            } else if (typeof Main.keyboard.show === 'function') {
+                Main.keyboard.show(0); // from 3.28 to 3.31.2
+            } else {
+                Main.keyboard.open(0); // since 3.31.2
+            }
         }));
         global.stage.add_action(gesture);
 }


### PR DESCRIPTION
This is a hack to handle the fact that the function that opens the GNOME Shell on-screen keyboard keeps getting its name changed:

up to 3.28: Show()
3.28 to 3.31.2: show()
3.31.2 onward: open()

